### PR TITLE
fix(FlashImage):#59

### DIFF
--- a/src/graia/application/message/chain.py
+++ b/src/graia/application/message/chain.py
@@ -214,7 +214,7 @@ class MessageChain(BaseModel):
         Returns:
             List[T]: 获取到的符合要求的所有消息元素; 另: 可能是空列表([]).
         """
-        return [i for i in self.__root__ if isinstance(i, element_class)]
+        return [i for i in self.__root__ if type(i) is element_class]
 
     def asDisplay(self) -> str:
         """获取以字符串形式表示的消息链, 且趋于通常你见到的样子.

--- a/src/graia/application/message/elements/external.py
+++ b/src/graia/application/message/elements/external.py
@@ -10,7 +10,7 @@ class Image(ExternalElement):
     def asSerializationString(self) -> str:
         return f"[mirai:image:{self.imageId}]"
 
-class FlashImage(Image):
+class FlashImage(Image, ExternalElement):
     type = "FlashImage"
 
     def asSerializationString(self) -> str:


### PR DESCRIPTION
将external中的FlashImage类继承了ExternalElement
并将来MessageChain.get中的`isinstance(i, element_class)`改为`type(i) is element_class`防止在获取Image的时候获取到FlashImage类